### PR TITLE
clover auxilliary index "icy" was defined in the wrong place for OpenMP

### DIFF
--- a/clover.c
+++ b/clover.c
@@ -175,9 +175,9 @@ void H_eo_sw_inv_psi(spinor * const l, spinor * const k, const int ieo, const do
 void clover_inv(const int ieo, spinor * const l, const double mu) {
 #ifdef OMP
 #define static
-  int icy;
 #pragma omp parallel
   {
+  int icy;
 #endif    
   static su3_vector psi, chi, phi1, phi3;
   int ioff = 0;

--- a/clover_leaf.c
+++ b/clover_leaf.c
@@ -493,9 +493,9 @@ void mult_6x6(_Complex double a[6][6], _Complex double b[6][6], _Complex double 
 void sw_invert(const int ieo, const double mu) {
 #ifdef OMP
 #define static
-  int icy;
 #pragma omp parallel
   {
+  int icy;
 #endif
   int ioff, err=0;
   int i, x;
@@ -598,9 +598,9 @@ void sw_invert(const int ieo, const double mu) {
 void sw_deriv(const int ieo, const double mu) {
 #ifdef OMP
 #define static
-  int icy;
 #pragma omp parallel
   {
+  int icy;
 #endif
 
   int ioff;


### PR DESCRIPTION
fixes loss of acceptance with OpenMP and clover monomials due to human error in bgq/openmp merge

a remaining caveat is that there exists a possibility that in sw_all the *_add_assign macros write into the same memory location from multiple threads
