### PR TITLE
Adjust debug levels to improve output at level 1 and 2

### DIFF
--- a/monomial/cloverdet_monomial.c
+++ b/monomial/cloverdet_monomial.c
@@ -131,7 +131,7 @@ void cloverdet_derivative(const int id, hamiltonian_field_t * const hf) {
   g_mu3 = 0.;
   boundary(g_kappa);
   etime = gettime();
-  if(g_debug_level > 0 && g_proc_id == 0) {
+  if(g_debug_level > 1 && g_proc_id == 0) {
     printf("# Time for %s monomial derivative: %e s\n", mnl->name, etime-atime);
   }
   return;

--- a/monomial/cloverdetratio_monomial.c
+++ b/monomial/cloverdetratio_monomial.c
@@ -142,7 +142,7 @@ void cloverdetratio_derivative_orig(const int no, hamiltonian_field_t * const hf
   g_mu3 = 0.;
   boundary(g_kappa);
   etime = gettime();
-  if(g_debug_level > 0 && g_proc_id == 0) {
+  if(g_debug_level > 1 && g_proc_id == 0) {
     printf("# Time for %s monomial derivative: %e s\n", mnl->name, etime-atime);
   }
   return;

--- a/monomial/cloverndpoly_monomial.c
+++ b/monomial/cloverndpoly_monomial.c
@@ -131,7 +131,7 @@ void cloverndpoly_derivative(const int id, hamiltonian_field_t * const hf) {
   sw_deriv_nd(EE);
   sw_all(hf, mnl->kappa, mnl->c_sw);
   etime = gettime();
-  if(g_debug_level > 0 && g_proc_id == 0) {
+  if(g_debug_level > 1 && g_proc_id == 0) {
     printf("# Time for %s monomial derivative: %e s\n", mnl->name, etime-atime);
   }
   return;

--- a/monomial/det_monomial.c
+++ b/monomial/det_monomial.c
@@ -143,7 +143,7 @@ void det_derivative(const int id, hamiltonian_field_t * const hf) {
   g_mu = g_mu1;
   boundary(g_kappa);
   etime = gettime();
-  if(g_debug_level > 0 && g_proc_id == 0) {
+  if(g_debug_level > 1 && g_proc_id == 0) {
     printf("# Time for %s monomial derivative: %e s\n", mnl->name, etime-atime);
   }
   return;

--- a/monomial/detratio_monomial.c
+++ b/monomial/detratio_monomial.c
@@ -186,7 +186,7 @@ void detratio_derivative(const int no, hamiltonian_field_t * const hf) {
   g_mu = g_mu1;
   boundary(g_kappa);
   etime = gettime();
-  if(g_debug_level > 0 && g_proc_id == 0) {
+  if(g_debug_level > 1 && g_proc_id == 0) {
     printf("# Time for %s monomial derivative: %e s\n", mnl->name, etime-atime);
   }
   return;

--- a/monomial/gauge_monomial.c
+++ b/monomial/gauge_monomial.c
@@ -89,7 +89,7 @@ void gauge_derivative(const int id, hamiltonian_field_t * const hf) {
   } /* OpenMP closing brace */
 #endif
   etime = gettime();
-  if(g_debug_level > 0 && g_proc_id == 0) {
+  if(g_debug_level > 1 && g_proc_id == 0) {
     printf("# Time for %s monomial derivative: %e s\n", mnl->name, etime-atime);
   }
   return;

--- a/monomial/ndpoly_monomial.c
+++ b/monomial/ndpoly_monomial.c
@@ -158,7 +158,7 @@ void ndpoly_derivative(const int id, hamiltonian_field_t * const hf) {
     using mnl->forcefactor
   */ 
   etime = gettime();
-  if(g_debug_level > 0 && g_proc_id == 0) {
+  if(g_debug_level > 1 && g_proc_id == 0) {
     printf("# Time for %s monomial derivative: %e s\n", mnl->name, etime-atime);
   }
   return;

--- a/monomial/poly_monomial.c
+++ b/monomial/poly_monomial.c
@@ -174,7 +174,7 @@ void poly_derivative(const int id, hamiltonian_field_t * const hf){
   boundary(g_kappa);
   popPhmcVars();
   etime = gettime();
-  if(g_debug_level > 0 && g_proc_id == 0) {
+  if(g_debug_level > 1 && g_proc_id == 0) {
     printf("# Time for %s monomial derivative: %e s\n", mnl->name, etime-atime);
   }
   return;

--- a/solver/bicgstab_complex.c
+++ b/solver/bicgstab_complex.c
@@ -78,7 +78,7 @@ int bicgstab_complex(spinor * const P,spinor * const Q, const int max_iter,
 
   for(i = 0; i < max_iter; i++){
     err = square_norm(r, N, 1);
-    if(g_proc_id == g_stdio_proc && g_debug_level > 1) {
+    if(g_proc_id == g_stdio_proc && g_debug_level > 2) {
       printf("%d %e\n", i, err);
       fflush(stdout);
     }

--- a/solver/bicgstab_complex_bi.c
+++ b/solver/bicgstab_complex_bi.c
@@ -78,7 +78,7 @@ int bicgstab_complex_bi(bispinor * const P, bispinor * const Q, const int max_it
 
   for(i = 0; i < max_iter; i++){
     err = square_norm((spinor*)r, 2*N, 1);
-    if(g_proc_id == g_stdio_proc && g_debug_level > 1) {
+    if(g_proc_id == g_stdio_proc && g_debug_level > 2) {
       printf("%d %e\n", i, err);
       fflush(stdout);
     }

--- a/solver/bicgstabell.c
+++ b/solver/bicgstabell.c
@@ -108,7 +108,7 @@ int bicgstabell(spinor * const x0, spinor * const b, const int max_iter,
       /* x = x + \alpha u_0 */
       assign_add_mul_r(x, u[0], alpha, N);
       err = square_norm(r[j+1], N, 1);
-      if(g_proc_id == 0 && g_debug_level > 1) {printf("%d %d err = %e\n", k, j, err);fflush(stdout);}
+      if(g_proc_id == 0 && g_debug_level > 2) {printf("%d %d err = %e\n", k, j, err);fflush(stdout);}
     }
 
     /* The MR part */

--- a/solver/cg_her.c
+++ b/solver/cg_her.c
@@ -100,7 +100,7 @@ int cg_her(spinor * const P, spinor * const Q, const int max_iter,
     err = assign_mul_add_r_and_square(solver_field[0], -alpha_cg, solver_field[1], N, 1);
 #endif
 
-    if(g_proc_id == g_stdio_proc && g_debug_level > 1) {
+    if(g_proc_id == g_stdio_proc && g_debug_level > 2) {
       printf("CG: iterations: %d res^2 %e\n", iteration, err);
       fflush(stdout);
     }

--- a/solver/cg_her_bi.c
+++ b/solver/cg_her_bi.c
@@ -116,7 +116,7 @@ int cg_her_bi(bispinor * const P, bispinor * const Q, const int max_iter,
     /* Check whether the precision is reached ... */
     err=square_norm((spinor*)bisolver_field[1], 2*N, 1);
 
-    if((g_proc_id == g_stdio_proc) && (g_debug_level > 1)) {
+    if((g_proc_id == g_stdio_proc) && (g_debug_level > 2)) {
       printf("%d\t%g\n",iteration,err); fflush( stdout);
     }
     

--- a/solver/cg_her_nd.c
+++ b/solver/cg_her_nd.c
@@ -125,7 +125,7 @@ int cg_her_nd(spinor * const P_up,spinor * P_dn, spinor * const Q_up, spinor * c
     err1 =square_norm(up_field[1], N, 1);
     err2 =square_norm(dn_field[1], N, 1);
     err = err1 + err2;
-    if(g_debug_level > 1 && g_proc_id == g_stdio_proc) {
+    if(g_debug_level > 2 && g_proc_id == g_stdio_proc) {
       printf("cg_her_nd : i = %d  esqr  %e = %e + %e \n",iteration,err, err1, err2); fflush( stdout);
     }
 

--- a/solver/cg_her_su3vect.c
+++ b/solver/cg_her_su3vect.c
@@ -72,7 +72,7 @@ int cg_her_su3vect(su3_vector * const P, su3_vector * const Q, const int max_ite
     assign_mul_add_r_su3vect(g_jacobi_field[0], -alpha_cg, g_jacobi_field[1], N);
     err=square_norm_su3vect(g_jacobi_field[0], N, 1);
 
-    if(g_proc_id == g_stdio_proc && g_debug_level > 1) {
+    if(g_proc_id == g_stdio_proc && g_debug_level > 2) {
       printf("CG: iterations: %d res^2 %e\n", iteration, err);
       fflush(stdout);
     }

--- a/solver/cgs_real.c
+++ b/solver/cgs_real.c
@@ -64,7 +64,7 @@ int cgs_real(spinor * const P, spinor * const Q, const int max_iter,
   /* loop! */
   for(i=0;i<=max_iter;i++) {
     res_sq=square_norm(solver_field[0], N, 1);
-    if(g_proc_id == g_stdio_proc && g_debug_level > 0) {
+    if(g_proc_id == g_stdio_proc && g_debug_level > 2) {
       printf("%d\t%g\n",i,res_sq); 
       fflush( stdout );
     }

--- a/solver/gcr.c
+++ b/solver/gcr.c
@@ -84,7 +84,7 @@ int gcr(spinor * const P, spinor * const Q,
     f(tmp, P);
     diff(rho, Q, tmp, N);
     err = square_norm(rho, N, 1);
-    if(g_proc_id == g_stdio_proc && g_debug_level > 2){
+    if(g_proc_id == g_stdio_proc && g_debug_level > 1){
       printf("GCR: iteration number: %d, true residue: %g\n", iter, err); 
       fflush(stdout);
     }
@@ -118,7 +118,7 @@ int gcr(spinor * const P, spinor * const Q,
       assign_diff_mul(rho, chi[k], c[k], N);
       err = square_norm(rho, N, 1);
       iter ++;
-      if(g_proc_id == g_stdio_proc && g_debug_level > 0){
+      if(g_proc_id == g_stdio_proc && g_debug_level > 2){
         if(rel_prec == 1) printf("# GCR: %d\t%g >= %g iterated residue\n", iter, err, eps_sq*norm_sq); 
         else printf("# GCR: %d\t%g >= %giterated residue\n", iter, err, eps_sq);
         fflush(stdout);

--- a/solver/jdher.c
+++ b/solver/jdher.c
@@ -170,7 +170,7 @@ void jdher(int n, int lda, double tau, double tol,
 
 
   /* print info header */
-  if ((verbosity >= 2) && (g_proc_id == 0)){
+  if ((verbosity > 2) && (g_proc_id == 0)){
     printf("Jacobi-Davidson method for hermitian Matrices\n");
     printf("Solving  A*x = lambda*x \n\n");
     printf("  N=      %10d  ITMAX=%4d\n", n, itmax);
@@ -735,7 +735,7 @@ static void print_status(int verbosity, int it, int k, int j, int kmax,
 
   int i, idummy;
 
-  if (verbosity >= 2) {
+  if (verbosity > 2) {
     if (blksize == 1) {
       if (it == 0) {
 	printf("  IT   K   J       RES LINIT RITZ-VALUES(1:5)\n");

--- a/solver/jdher_bi.c
+++ b/solver/jdher_bi.c
@@ -166,7 +166,7 @@ void jdher_bi(int n, int lda, double tau, double tol,
   /* END NEW PART */
 
   /* print info header */
-  if (verbosity > 1 && g_proc_id == 0) {
+  if (verbosity > 2 && g_proc_id == 0) {
     printf("Jacobi-Davidson method for hermitian Matrices\n");
     printf("Solving  A*x = lambda*x \n\n");
     printf("  N=      %10d  ITMAX=%4d\n", n, itmax);
@@ -718,7 +718,7 @@ static void print_status(int verbosity, int it, int k, int j, int kmax,
 
   int i, idummy;
 
-  if (verbosity >= 2) {
+  if (verbosity > 2) {
     if (blksize == 1) {
       if (it == 0) {
 	printf("  IT   K   J       RES LINIT RITZ-VALUES(1:5)\n");

--- a/solver/jdher_su3vect.c
+++ b/solver/jdher_su3vect.c
@@ -133,7 +133,7 @@ int ISEED[4] = {2, 3, 5, 7};
  ISEED[0] = 2;
   
 	/* print info header */
- if ((verbosity > 0) && (g_proc_id == 0)){
+ if ((verbosity > 2) && (g_proc_id == 0)){
    printf("Jacobi-Davidson method for hermitian Matrices\n");
    printf("Solving  A*x = lambda*x \n\n");
    printf("  N=      %10d  ITMAX=%4d\n", n, itmax);
@@ -654,7 +654,7 @@ int ISEED[4] = {2, 3, 5, 7};
     A_psi((su3_vector*) r, (su3_vector*) q,tslice);
     _FT(daxpy)(&n2, &theta, (double*) q, &ONE, (double*) r, &ONE);
     alpha = sqrt(square_norm_su3vect((su3_vector*) r, N, 1));
-    if(g_proc_id == 0 && verbosity > 0) {
+    if(g_proc_id == 0 && verbosity > 1) {
       printf("%3d %22.15e %12.5e\n", act+1, lambda[act], alpha);
     }
   }
@@ -690,7 +690,7 @@ static void print_status_su3vect(int verbosity, int it, int k, int j, int kmax,
 
   int i, idummy;
 
-  if (verbosity >= 2) {
+  if (verbosity > 2) {
     if (blksize == 1) {
       if (it == 0) {
 	printf("  IT   K   J       RES LINIT RITZ-VALUES(1:5)\n");

--- a/solver/pcg_her.c
+++ b/solver/pcg_her.c
@@ -90,7 +90,7 @@ int pcg_her(spinor * const P, spinor * const Q, const int max_iter,
 
     /* Check whether the precision is reached ... */
     err=square_norm(solver_field[1], N, 1);
-    if(g_debug_level > 0 && g_proc_id == g_stdio_proc) {
+    if(g_debug_level > 1 && g_proc_id == g_stdio_proc) {
       printf("%d\t%g\n",iteration,err); fflush( stdout);
     }
 

--- a/update_gauge.c
+++ b/update_gauge.c
@@ -103,7 +103,7 @@ void update_gauge(const double step, hamiltonian_field_t * const hf) {
   hf->update_rectangle_energy = 1;
   g_update_rectangle_energy = 1;
   etime = gettime();
-  if(g_debug_level > 0 && g_proc_id == 0) {
+  if(g_debug_level > 1 && g_proc_id == 0) {
     printf("# Time gauge update: %e s\n", etime-atime); 
   } 
   return;


### PR DESCRIPTION
This pull-request adjusts the debug levels of the new timing information and the solver execution statistics.

In summary:
1. provides basic information (such as number of iterations, max/min eigenvalues)
2. provides additional timing information
3. provides extended information in jdher and output for every iteration of the solvers

This results in clearer output at level 1 and 2, in line with what I believe would be user expectations.
